### PR TITLE
Proposal to allow custom Descriptors via hooks

### DIFF
--- a/docs/descriptor.rst
+++ b/docs/descriptor.rst
@@ -106,6 +106,8 @@ Descriptors that are downloaded (cached) to the local disk are called **download
 The **app_store**, **shotgun**, **git** and **git_branch** descriptors are downloadable descriptors,
 while the **path**, **dev** and **manual** descriptors are accessed directly from the specified path.
 
+.. note:: To add custom descriptor types via a hook,
+    see :ref:`Customizing Descriptor Types<customizing_descriptor_types>`.
 
 .. _app_store_descriptor:
 
@@ -561,6 +563,52 @@ for the code in the ``BUNDLE_CACHE/manual/tk-nuke-publish/v0.5.0`` folder.
 
 .. warning:: Manual descriptors are part of an older toolkit workflow methodology and while they are supported,
     we do not recommend using them.
+
+
+.. _customizing_descriptor_types:
+
+Adding Custom Descriptor Types
+===============================================
+
+Shotgun toolkit allows you to provide additional descriptor grammar with custom Descriptor classes.
+
+This can be done by overriding the ``register_descriptor.py`` core hook.
+
+The ``register_descriptor.py`` hook consists of only two methods:
+
+=================================== ===========================================================================
+Method Name                         Description
+=================================== ===========================================================================
+init                                Standard hook initialization. Used to provide access to a shotgun instance,
+                                    the id of the pipeline that we are bootstrapping into, and a reference to
+                                    the ConfigDescriptor that we are bootstrapping into. It also creates a
+                                    reference to both IODescriptor and Descriptor base classes if needed.
+
+register_io_descriptors             Used to register additional IODescriptor subclasses. Use
+                                    ``self.io_descriptor_base.register_descriptor_factory(name, klass)`` to
+                                    link your custom descriptor grammar to a Python class.
+
+=================================== ===========================================================================
+
+
+An example of registering a custom IODescriptor for a bitbucket release would look similar to the following:
+
+.. literalinclude:: examples/register_descriptor_hook.py
+   :language: python
+   :start-after: #documentationStart
+   :end-before: #documentationEnd
+
+
+With the hook implemented and accessible from your config, you should be able to use the following app descriptor
+
+.. code-block:: yaml
+
+    {
+        type: bitbucket_release,
+        organization: mycompany,
+        repository: tk-multi-autocomp,
+        version: v0.1.0
+    }
 
 
 Environment Variables

--- a/docs/examples/register_descriptor_hook.py
+++ b/docs/examples/register_descriptor_hook.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+# This file is included in the sphinx documentation as an example. Keep this in mind
+# when editing it.
+
+# Everything after this line will be part of the documentation. #documentationStart
+import os
+
+from sgtk import get_hook_baseclass
+from sgtk.descriptor.io_descriptor.downloadable import IODescriptorDownloadable
+from sgtk.descriptor.errors import TankError, TankDescriptorError
+from sgtk.util.shotgun import download
+
+
+class IODescriptorBitbucketRelease(IODescriptorDownloadable):
+    def __init__(self, descriptor_dict, sg_connection, bundle_type):
+        """
+        Constructor
+
+        :param descriptor_dict: descriptor dictionary describing the bundle
+        :param sg_connection: Shotgun connection to associated site.
+        :param bundle_type: Either AppDescriptor.APP, CORE, ENGINE or FRAMEWORK.
+        :return: Descriptor instance
+        """
+        super(IODescriptorBitbucketRelease, self).__init__(
+            descriptor_dict, sg_connection, bundle_type
+        )
+        self._validate_descriptor(
+            descriptor_dict,
+            required=["type", "organization", "repository", "version"],
+            optional=[],
+        )
+        self._sg_connection = sg_connection
+        self._bundle_type = bundle_type
+        self._organization = descriptor_dict["organization"]
+        self._repository = descriptor_dict["repository"]
+        self._version = descriptor_dict["version"]
+
+    def _get_bundle_cache_path(self, bundle_cache_root):
+        """
+        Given a cache root, compute a cache path suitable
+        for this descriptor, using the 0.18+ path format.
+
+        :param bundle_cache_root: Bundle cache root path
+        :return: Path to bundle cache location
+        """
+        return os.path.join(
+            bundle_cache_root,
+            "bitbucket",
+            self._organization,
+            self.get_system_name(),
+            self.get_version(),
+        )
+
+    def get_system_name(self):
+        """
+        Returns a short name, suitable for use in configuration files
+        and for folders on disk, e.g. 'tk-maya'
+        """
+        return self._repository
+
+    def get_version(self):
+        """
+        Returns the version number string for this item.
+        In this case, this is the linked shotgun attachment id.
+        """
+        return self._version
+
+    def _download_local(self, destination_path):
+        """
+        Retrieves this version to local repo.
+        Will exit early if app already exists local.
+
+        :param destination_path: The directory path to which the shotgun entity is to be
+        downloaded to.
+        """
+        url = "https://bitbucket.org/{organization}/{system_name}/get/{version}.zip"
+        url = url.format(
+            organization=self._organization,
+            system_name=self.get_system_name(),
+            version=self.get_version(),
+        )
+
+        try:
+            download.download_and_unpack_url(
+                self._sg_connection, url, destination_path, auto_detect_bundle=True
+            )
+        except TankError as e:
+            raise TankDescriptorError(
+                "Failed to download %s from %s. Error: %s" % (self, url, e)
+            )
+
+
+class MyCustomRegisterDescriptorsHook(get_hook_baseclass()):
+    def register_io_descriptors(self):
+        # To register the default IODescriptor classes
+        super(MyCustomRegisterDescriptorsHook, self).register_io_descriptors()
+        self.io_descriptor_base.register_descriptor_factory(
+            "bitbucket_release", IODescriptorBitbucketRelease
+        )
+
+
+# Everything after this line will not be part of the documentation. #documentationEnd

--- a/hooks/register_descriptor.py
+++ b/hooks/register_descriptor.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2020 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+This hook is used override some of the functionality of the :class:`~sgtk.bootstrap.ToolkitManager`.
+
+It will be instantiated only after a configuration has been selected by the :class:`~sgtk.bootstrap.ToolkitManager`.
+Therefore, this hook will not be invoked to download a configuration. However, the Toolkit Core,
+applications, frameworks and engines can be downloaded through the hook.
+"""
+
+from sgtk import get_hook_baseclass
+
+
+class RegisterDescriptors(get_hook_baseclass()):
+    def init(
+        self, shotgun, pipeline_configuration_id, configuration_descriptor, **kwargs
+    ):
+        """
+        Initializes the hook.
+
+        This method is called right after the bootstrap manager reads this hook and passes in
+        information about the pipeline configuration that will be used.
+
+        The default implementation copies the arguments into the attributes named ``shotgun``,
+        ``pipeline_configuration_id`` and ``configuration_descriptor``.
+
+        :param shotgun: Connection to the Shotgun site.
+        :type shotgun: :class:`~shotgun_api3.Shotgun`
+
+        :param int pipeline_configuration_id: Id of the pipeline configuration we're bootstrapping into.
+            If None, the ToolkitManager is bootstrapping into the base configuration.
+
+        :param configuration_descriptor: Configuration the manager is bootstrapping into.
+        :type configuration_descriptor: :class:`~sgtk.descriptor.ConfigDescriptor`
+        """
+        self.shotgun = shotgun
+        self.pipeline_configuration_id = pipeline_configuration_id
+        self.configuration_descriptor = configuration_descriptor
+
+        from sgtk.descriptor.io_descriptor.base import IODescriptorBase
+
+        self.io_descriptor_base = IODescriptorBase
+
+    def register_io_descriptors(self):
+        """
+        Register the IODescriptor subclasses with the IODescriptorBase factory.
+        This complex process for handling the IODescriptor abstract factory
+        management is in order to avoid local imports in classes.
+        """
+        from sgtk.descriptor.io_descriptor import _initialize_descriptor_factory
+
+        _initialize_descriptor_factory(self.io_descriptor_base)

--- a/hooks/register_descriptor.py
+++ b/hooks/register_descriptor.py
@@ -32,6 +32,10 @@ class RegisterDescriptors(get_hook_baseclass()):
         The default implementation copies the arguments into the attributes named ``shotgun``,
         ``pipeline_configuration_id`` and ``configuration_descriptor``.
 
+        Additional attributes of note are ``io_descriptor_base``
+            which are the base classes that you register types against using the
+            ``register_descriptor_factory`` method.
+
         :param shotgun: Connection to the Shotgun site.
         :type shotgun: :class:`~shotgun_api3.Shotgun`
 

--- a/python/tank/descriptor/errors.py
+++ b/python/tank/descriptor/errors.py
@@ -24,6 +24,12 @@ class TankDescriptorError(TankError):
     pass
 
 
+class RegisterDescriptorError(TankDescriptorError):
+    """
+    Errors indicating an error during registration of custom descriptor types.
+    """
+
+
 class TankDescriptorIOError(TankDescriptorError):
     """
     Base class for all descriptor I/O related errors.

--- a/python/tank/descriptor/io_descriptor/__init__.py
+++ b/python/tank/descriptor/io_descriptor/__init__.py
@@ -16,7 +16,7 @@ from .factory import (
 )
 
 
-def _initialize_descriptor_factory():
+def _initialize_descriptor_factory(io_descriptor_base):
     """
     Register the IODescriptor subclasses with the IODescriptorBase factory.
     This complex process for handling the IODescriptor abstract factory
@@ -32,13 +32,13 @@ def _initialize_descriptor_factory():
     from .github_release import IODescriptorGithubRelease
     from .manual import IODescriptorManual
 
-    IODescriptorBase.register_descriptor_factory("app_store", IODescriptorAppStore)
-    IODescriptorBase.register_descriptor_factory("dev", IODescriptorDev)
-    IODescriptorBase.register_descriptor_factory("path", IODescriptorPath)
-    IODescriptorBase.register_descriptor_factory("shotgun", IODescriptorShotgunEntity)
-    IODescriptorBase.register_descriptor_factory("git", IODescriptorGitTag)
-    IODescriptorBase.register_descriptor_factory("git_branch", IODescriptorGitBranch)
-    IODescriptorBase.register_descriptor_factory(
+    io_descriptor_base.register_descriptor_factory("app_store", IODescriptorAppStore)
+    io_descriptor_base.register_descriptor_factory("dev", IODescriptorDev)
+    io_descriptor_base.register_descriptor_factory("path", IODescriptorPath)
+    io_descriptor_base.register_descriptor_factory("shotgun", IODescriptorShotgunEntity)
+    io_descriptor_base.register_descriptor_factory("git", IODescriptorGitTag)
+    io_descriptor_base.register_descriptor_factory("git_branch", IODescriptorGitBranch)
+    io_descriptor_base.register_descriptor_factory(
         "github_release", IODescriptorGithubRelease
     )
-    IODescriptorBase.register_descriptor_factory("manual", IODescriptorManual)
+    io_descriptor_base.register_descriptor_factory("manual", IODescriptorManual)

--- a/python/tank/descriptor/io_descriptor/__init__.py
+++ b/python/tank/descriptor/io_descriptor/__init__.py
@@ -42,7 +42,3 @@ def _initialize_descriptor_factory():
         "github_release", IODescriptorGithubRelease
     )
     IODescriptorBase.register_descriptor_factory("manual", IODescriptorManual)
-
-
-_initialize_descriptor_factory()
-del _initialize_descriptor_factory

--- a/tests/descriptor_tests/test_io_descriptors.py
+++ b/tests/descriptor_tests/test_io_descriptors.py
@@ -217,6 +217,40 @@ class TestIODescriptors(ShotgunTestBase):
             ],
         )
 
+    def test_custom_io_descriptor_type(self):
+        config_root = os.path.join(self.fixtures_root, "config")
+        sg = self.mockgun
+
+        d = sgtk.descriptor.create_descriptor(
+            self.mockgun,
+            sgtk.descriptor.Descriptor.CONFIG,
+            {
+                "type": "dev",
+                "path": config_root,
+                "version": "v0.1.0",
+                "name": "tk-core",
+            },
+        )
+
+        location = {
+            "type": "bitbucket_release",
+            "organization": "tk-core-testing",
+            "repository": "tk-multi-demo",
+            "version": "v0.1.0",
+        }
+
+        downloads_root = os.path.join(self.fixtures_root, "config")
+        tk_bundle_app = sgtk.descriptor.create_descriptor(
+            sg,
+            sgtk.descriptor.Descriptor.APP,
+            location,
+            bundle_cache_root_override=downloads_root,
+        )
+        tk_bundle_app._io_descriptor.ensure_local()
+        self.assertTrue(
+            os.path.exists(tk_bundle_app._io_descriptor._get_primary_cache_path())
+        )
+
     def test_download_receipt(self):
         """
         Tests the download receipt logic

--- a/tests/fixtures/config/core/hooks/register_descriptor.py
+++ b/tests/fixtures/config/core/hooks/register_descriptor.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2020 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+This hook is used override some of the functionality of the :class:`~sgtk.bootstrap.ToolkitManager`.
+
+It will be instantiated only after a configuration has been selected by the :class:`~sgtk.bootstrap.ToolkitManager`.
+Therefore, this hook will not be invoked to download a configuration. However, the Toolkit Core,
+applications, frameworks and engines can be downloaded through the hook.
+"""
+import os
+
+from sgtk import get_hook_baseclass
+from sgtk.descriptor.io_descriptor.downloadable import IODescriptorDownloadable
+from sgtk.descriptor.errors import TankError, TankDescriptorError
+from sgtk.util.shotgun import download
+
+
+class IODescriptorBitbucketRelease(IODescriptorDownloadable):
+    def __init__(self, descriptor_dict, sg_connection, bundle_type):
+        """
+        Constructor
+
+        :param descriptor_dict: descriptor dictionary describing the bundle
+        :param sg_connection: Shotgun connection to associated site.
+        :param bundle_type: Either AppDescriptor.APP, CORE, ENGINE or FRAMEWORK.
+        :return: Descriptor instance
+        """
+        super(IODescriptorBitbucketRelease, self).__init__(
+            descriptor_dict, sg_connection, bundle_type
+        )
+        self._validate_descriptor(
+            descriptor_dict,
+            required=["type", "organization", "repository", "version"],
+            optional=[],
+        )
+        self._sg_connection = sg_connection
+        self._bundle_type = bundle_type
+        self._organization = descriptor_dict["organization"]
+        self._repository = descriptor_dict["repository"]
+        self._version = descriptor_dict["version"]
+
+    def _get_bundle_cache_path(self, bundle_cache_root):
+        """
+        Given a cache root, compute a cache path suitable
+        for this descriptor, using the 0.18+ path format.
+
+        :param bundle_cache_root: Bundle cache root path
+        :return: Path to bundle cache location
+        """
+        return os.path.join(
+            bundle_cache_root,
+            "bitbucket",
+            self._organization,
+            self.get_system_name(),
+            self.get_version(),
+        )
+
+    def get_system_name(self):
+        """
+        Returns a short name, suitable for use in configuration files
+        and for folders on disk, e.g. 'tk-maya'
+        """
+        return self._repository
+
+    def get_version(self):
+        """
+        Returns the version number string for this item.
+        In this case, this is the linked shotgun attachment id.
+        """
+        return self._version
+
+    def _download_local(self, destination_path):
+        """
+        Retrieves this version to local repo.
+        Will exit early if app already exists local.
+
+        :param destination_path: The directory path to which the shotgun entity is to be
+        downloaded to.
+        """
+        url = "https://bitbucket.org/{organization}/{system_name}/get/{version}.zip"
+        url = url.format(
+            organization=self._organization,
+            system_name=self.get_system_name(),
+            version=self.get_version(),
+        )
+
+        try:
+            download.download_and_unpack_url(
+                self._sg_connection, url, destination_path, auto_detect_bundle=True
+            )
+        except TankError as e:
+            raise TankDescriptorError(
+                "Failed to download %s from %s. Error: %s" % (self, url, e)
+            )
+
+
+class MyCustomRegisterDescriptorsHook(get_hook_baseclass()):
+    def register_io_descriptors(self):
+        # To register the default IODescriptor classes
+        super(MyCustomRegisterDescriptorsHook, self).register_io_descriptors()
+        self.io_descriptor_base.register_descriptor_factory(
+            "bitbucket_release", IODescriptorBitbucketRelease
+        )


### PR DESCRIPTION
This PR is to allow toolkit developers to write custom Descriptor and IODescriptor classes without needing to take ownership over the entire tk-core repository.

We are no longer relying on a function in the __init__.py of `tank.descriptor` and `tank.descriptor.io_descriptor` to register our Descriptor types.  
We have offloaded that job to a DescriptorManager class that calls out to a new core hook `register_descriptor.py`.

I have also added a sample use case for implementing a `bitbucket_release` IODescriptor example based off of the `github_release` IODescriptor